### PR TITLE
Support message for sending players between servers.

### DIFF
--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -144,6 +144,12 @@ pub enum OutgoingMessage {
     Command {
         command: String,
         sender: String,
+    },
+    #[serde(rename = "send_to_server")]
+    SendToServer {
+        // The UUID
+        player: String,
+        target_server: String,
     }
 }
 


### PR DESCRIPTION
Adds a new `OutgoingMessage` type for instructing the velocity proxy to move a player between servers, and a message that can be sent to an `IntegrationsClient` to trigger the packet to be sent.

(this is my first time using the `xtra` framework, so I hope I got this correct)