### PR TITLE
'Smart' kickback

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Config {
@@ -9,6 +10,7 @@ pub struct Config {
     pub integrations: Option<IntegrationsConfig>,
     pub discord: Option<DiscordConfig>,
     pub database: Option<DatabaseConfig>,
+    pub kickbacks: HashMap<String, Kickback>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -36,6 +38,13 @@ pub struct DatabaseConfig {
     pub database: String,
     pub user: String,
     pub password: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Kickback {
+    pub to_server: String,
+    pub from_server: String,
+    pub proxy_channel: String,
 }
 
 pub(super) fn load() -> Config {

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -150,6 +150,11 @@ pub enum OutgoingMessage {
         // The UUID
         player: String,
         target_server: String,
+    },
+    #[serde(rename = "send_server_to_server")]
+    SendServerToServer {
+        from_server: String,
+        to_server: String,
     }
 }
 


### PR DESCRIPTION
This implements a system similar to the current [kickback](https://github.com/NucleoidMC/kickback) plugin, but only attempts to send players away from the fallback when the target server comes back online.
This adds a new config option, `kickbacks`:
```json5
// Using JSON5 just for comments as explanations
{
  // [...] Skipped other config options such as discord and web_server

  "kickbacks": {
    "play": { // The name of the server integrations channel to watch for starting
      // The name of the server in the velocity proxy configuration to send players to
      "to_server": "play",
      // The name of the server in the velocity proxy configuration to send players from (to avoid, for example, moving players from the build server)
      "from_server": "fallback",
       // The name of the integrations channel for the velocity proxy
      "proxy_channel": "proxy"
    }
  }
}
```

Note: this also requires [the velocity plugin](https://github.com/NucleoidMC/nucleoid-extras-velocity) to be [updated](https://github.com/NucleoidMC/nucleoid-extras-velocity/commit/2202b19d0f48e6f2051216e58dc4e14f82f95f33) as well.