### PR TITLE
Send 404 response on web api for unknown channels

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -164,7 +164,7 @@ impl Message for ServerSystemMessage {
 pub struct GetStatus(pub String);
 
 impl Message for GetStatus {
-    type Result = ServerStatus;
+    type Result = Option<ServerStatus>;
 }
 
 #[async_trait]
@@ -362,8 +362,7 @@ impl Handler<ServerSystemMessage> for Controller {
 
 #[async_trait]
 impl Handler<GetStatus> for Controller {
-    async fn handle(&mut self, message: GetStatus, _ctx: &mut Context<Self>) -> ServerStatus {
+    async fn handle(&mut self, message: GetStatus, _ctx: &mut Context<Self>) -> Option<ServerStatus> {
         self.status_by_channel.get(&message.0).cloned()
-            .unwrap_or(ServerStatus::default())
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -23,7 +23,12 @@ pub async fn run(controller: Address<Controller>, config: WebServerConfig) {
 
 async fn get_status(controller: Address<Controller>, channel: String) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
     match controller.send(GetStatus(channel)).await {
-        Ok(status) => Ok(Box::new(warp::reply::json(&status))),
+        Ok(status) => {
+            Ok(match status {
+                Some(status) => Box::new(warp::reply::json(&status)),
+                None => Box::new(warp::reply::with_status("Not found", StatusCode::NOT_FOUND)),
+            })
+        },
         Err(err) => Ok(Box::new(warp::reply::with_status(format!("{:?}", err), StatusCode::INTERNAL_SERVER_ERROR))),
     }
 }


### PR DESCRIPTION
Rather than the current behavior of sending an 'empty' response like this: https://api.nucleoid.xyz/status/this-server-does-not-exist