### PR TITLE
Statistics backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
-
-[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,7 +1087,6 @@ dependencies = [
 name = "nucleoid-backend"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "bson",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,7 +2230,6 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.3",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,17 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
-name = "ahash"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
-dependencies = [
- "getrandom 0.2.3",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,7 +35,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "log",
- "pin-project 1.0.3",
+ "pin-project 1.0.8",
  "tokio",
  "tokio-rustls",
  "tungstenite 0.11.1",
@@ -137,24 +126,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bson"
-version = "2.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b02bc64b55fdb0d2b0833c0d1370ea4a814c15ada4740543a164c5158c0c03a"
-dependencies = [
- "ahash",
- "base64 0.13.0",
- "chrono",
- "hex",
- "indexmap",
- "lazy_static",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,12 +213,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2554a3155fec064362507487171dcc4edc3df60cb10f3a1fb10ed8094822b120"
+dependencies = [
+ "chrono",
+ "parse-zoneinfo",
+]
+
+[[package]]
+name = "clickhouse-rs"
+version = "1.0.0-alpha.1"
+source = "git+https://github.com/suharev7/clickhouse-rs?branch=async-await#68d9e55dfe38d0af276d61003563e54b3dce7f1c"
+dependencies = [
+ "byteorder",
+ "chrono",
+ "chrono-tz",
+ "clickhouse-rs-cityhash-sys",
+ "combine",
+ "crossbeam",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hostname",
+ "lazy_static",
+ "log",
+ "lz4",
+ "pin-project 1.0.8",
+ "thiserror",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "clickhouse-rs-cityhash-sys"
+version = "0.1.2"
+source = "git+https://github.com/suharev7/clickhouse-rs?branch=async-await#68d9e55dfe38d0af276d61003563e54b3dce7f1c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d47c1b11006b87e492b53b313bb699ce60e16613c4dddaa91f8f7c220ab2fa"
+dependencies = [
+ "bytes 1.0.1",
+ "memchr",
 ]
 
 [[package]]
@@ -278,6 +302,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,58 +377,6 @@ checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
-]
-
-[[package]]
-name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "data-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -364,18 +404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -429,7 +457,7 @@ checksum = "0362ef9c4c1fa854ff95b4cb78045a86e810d804dc04937961988b45427104a9"
 dependencies = [
  "futures-core",
  "futures-sink",
- "pin-project 1.0.3",
+ "pin-project 1.0.8",
  "spinning_top",
 ]
 
@@ -660,15 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,12 +695,6 @@ checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -763,7 +776,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.3",
+ "pin-project 1.0.8",
  "socket2 0.4.0",
  "tokio",
  "tower-service",
@@ -785,12 +798,6 @@ dependencies = [
  "tokio-rustls",
  "webpki",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -841,18 +848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
-dependencies = [
- "socket2 0.3.19",
- "widestring",
- "winapi",
- "winreg 0.6.2",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,12 +881,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if 0.1.10",
+ "serde",
 ]
 
 [[package]]
@@ -922,12 +912,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
+name = "lz4"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+checksum = "aac20ed6991e01bf6a2e68cc73df2b389707403662a8ba89f68511fb340f724c"
 dependencies = [
- "linked-hash-map",
+ "libc",
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -958,6 +959,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg 1.0.1",
+]
 
 [[package]]
 name = "mime"
@@ -1009,54 +1019,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mongodb"
-version = "2.0.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a21067b394508fd75179faee57ae1e21148e2faab21acb97ebc90e1d47fe0e8"
-dependencies = [
- "async-trait",
- "base64 0.13.0",
- "bitflags",
- "bson",
- "chrono",
- "derivative",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-util",
- "hex",
- "hmac",
- "lazy_static",
- "md-5",
- "os_info",
- "pbkdf2",
- "percent-encoding",
- "rand 0.8.4",
- "reqwest",
- "rustls",
- "serde",
- "serde_bytes",
- "serde_with",
- "sha-1 0.9.6",
- "sha2",
- "socket2 0.4.0",
- "stringprep",
- "strsim",
- "take_mut",
- "thiserror",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "trust-dns-proto",
- "trust-dns-resolver",
- "typed-builder",
- "uuid",
- "version_check",
- "webpki",
- "webpki-roots 0.21.1",
-]
-
-[[package]]
 name = "multipart"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,14 +1050,15 @@ name = "nucleoid-backend"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bson",
  "byteorder",
  "bytes 1.0.1",
+ "chrono",
+ "chrono-tz",
+ "clickhouse-rs",
  "env_logger",
  "futures",
  "lazy_static",
  "log",
- "mongodb",
  "regex",
  "reqwest",
  "serde",
@@ -1158,16 +1121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "os_info"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d2536ab8ff7605e8dc7044ec2f3eb0d49750cb559af9e5373c4564a3706cdd"
-dependencies = [
- "log",
- "winapi",
-]
-
-[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,12 +1146,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.7.5"
+name = "parse-zoneinfo"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
- "crypto-mac",
+ "regex",
 ]
 
 [[package]]
@@ -1236,11 +1189,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83804639aad6ba65345661744708855f9fbcb71176ea8d28d05aeb11d975e7"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
- "pin-project-internal 1.0.3",
+ "pin-project-internal 1.0.8",
 ]
 
 [[package]]
@@ -1256,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.3"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bcc46b8f73443d15bc1c5fecbb315718491fa9187fa483f0e359323cde8b3a"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1617,17 +1570,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.21.1",
- "winreg 0.7.0",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error",
+ "winreg",
 ]
 
 [[package]]
@@ -1666,12 +1609,6 @@ dependencies = [
  "sct",
  "webpki",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1732,15 +1669,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,7 +1685,6 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
- "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1773,29 +1700,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
-dependencies = [
- "rustversion",
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1952,12 +1856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,12 +1871,6 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
@@ -2142,7 +2034,7 @@ checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 1.0.3",
+ "pin-project 1.0.8",
  "tokio",
  "tungstenite 0.12.0",
 ]
@@ -2211,51 +2103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
-dependencies = [
- "async-trait",
- "cfg-if 1.0.0",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "lazy_static",
- "log",
- "rand 0.8.4",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
-dependencies = [
- "cfg-if 1.0.0",
- "futures-util",
- "ipconfig",
- "lazy_static",
- "log",
- "lru-cache",
- "parking_lot",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "trust-dns-proto",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,17 +2156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-builder"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345426c7406aa355b60c5007c79a2d1f5b605540072795222f17f6443e6a9c6f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typemap_rev"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,12 +2193,6 @@ checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"
@@ -2436,7 +2266,7 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding",
- "pin-project 1.0.3",
+ "pin-project 1.0.8",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -2568,12 +2398,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,15 +2427,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winreg"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14,6 +25,12 @@ checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "async-trait"
@@ -28,9 +45,9 @@ dependencies = [
 
 [[package]]
 name = "async-tungstenite"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce503a5cb1e7450af7d211b86b84807791b251f335b2f43f1e26b85a416f315"
+checksum = "f7cc5408453d37e2b1c6f01d8078af1da58b6cfa6a80fa2ede3bd2b9a6ada9c4"
 dependencies = [
  "futures-io",
  "futures-util",
@@ -38,8 +55,8 @@ dependencies = [
  "pin-project 1.0.3",
  "tokio",
  "tokio-rustls",
- "tungstenite",
- "webpki-roots",
+ "tungstenite 0.11.1",
+ "webpki-roots 0.20.0",
 ]
 
 [[package]]
@@ -50,7 +67,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -126,6 +143,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bson"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b02bc64b55fdb0d2b0833c0d1370ea4a814c15ada4740543a164c5158c0c03a"
+dependencies = [
+ "ahash",
+ "base64 0.13.0",
+ "chrono",
+ "hex",
+ "indexmap",
+ "lazy_static",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,6 +193,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cache-padded"
@@ -203,7 +244,7 @@ dependencies = [
  "num-traits",
  "serde",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -225,10 +266,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
+name = "cpufeatures"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -241,12 +285,64 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
 dependencies = [
  "generic-array 0.14.4",
  "subtle",
+]
+
+[[package]]
+name = "darling"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -268,18 +364,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -360,22 +462,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-
-[[package]]
 name = "futures"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -402,15 +488,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -419,16 +505,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg 1.0.1",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -437,18 +524,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
-dependencies = [
- "once_cell",
-]
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-timer"
@@ -458,10 +542,11 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -469,7 +554,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.3",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -486,7 +571,7 @@ dependencies = [
  "libc",
  "log",
  "rustc_version",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -520,12 +605,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.2.7"
+name = "getrandom"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "bytes",
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -536,14 +632,13 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
@@ -553,7 +648,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64 0.12.3",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "headers-core",
  "http",
  "mime",
@@ -571,6 +666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,13 +684,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "hmac"
-version = "0.9.0"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
 ]
 
 [[package]]
@@ -595,19 +716,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -633,11 +755,11 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -648,7 +770,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project 1.0.3",
- "socket2",
+ "socket2 0.4.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -657,11 +779,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
 dependencies = [
- "bytes",
  "futures-util",
  "hyper",
  "log",
@@ -670,6 +791,12 @@ dependencies = [
  "tokio-rustls",
  "webpki",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -684,9 +811,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
  "hashbrown",
@@ -698,7 +825,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
+dependencies = [
+ "bytes 1.0.1",
 ]
 
 [[package]]
@@ -711,12 +847,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
+name = "ipconfig"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
- "libc",
+ "socket2 0.3.19",
+ "widestring",
+ "winapi",
+ "winreg 0.6.2",
 ]
 
 [[package]]
@@ -741,16 +880,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,9 +887,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -793,16 +928,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
 
 [[package]]
 name = "memchr"
@@ -838,56 +993,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "miow",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
@@ -896,8 +1010,56 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
- "winapi 0.3.9",
+ "socket2 0.3.19",
+ "winapi",
+]
+
+[[package]]
+name = "mongodb"
+version = "2.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a21067b394508fd75179faee57ae1e21148e2faab21acb97ebc90e1d47fe0e8"
+dependencies = [
+ "async-trait",
+ "base64 0.13.0",
+ "bitflags",
+ "bson",
+ "chrono",
+ "derivative",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hmac",
+ "lazy_static",
+ "md-5",
+ "os_info",
+ "pbkdf2",
+ "percent-encoding",
+ "rand 0.8.4",
+ "reqwest",
+ "rustls",
+ "serde",
+ "serde_bytes",
+ "serde_with",
+ "sha-1 0.9.6",
+ "sha2",
+ "socket2 0.4.0",
+ "stringprep",
+ "strsim",
+ "take_mut",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "trust-dns-proto",
+ "trust-dns-resolver",
+ "typed-builder",
+ "uuid",
+ "version_check",
+ "webpki",
+ "webpki-roots 0.21.1",
 ]
 
 [[package]]
@@ -919,27 +1081,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
+name = "ntapi"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "nucleoid-backend"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "bson",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "env_logger",
  "futures",
  "lazy_static",
  "log",
+ "mongodb",
  "regex",
  "reqwest",
  "serde",
@@ -949,6 +1112,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-util",
+ "uuid",
  "warp",
  "xtra",
 ]
@@ -1001,6 +1165,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os_info"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3d2536ab8ff7605e8dc7044ec2f3eb0d49750cb559af9e5373c4564a3706cdd"
+dependencies = [
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,7 +1196,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf916dd32dd26297907890d99dc2740e33f6bd9073965af4ccff2967962f5508"
+dependencies = [
+ "crypto-mac",
 ]
 
 [[package]]
@@ -1091,15 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36743d754ccdf9954c2e352ce2d4b106e024c814f6499c2dadff80da9a442d8"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1115,29 +1292,29 @@ checksum = "9824e18e85003f0b5a38fa1932ae8be8c2aac9447c2f28ab6f9704dbe0a1ab58"
 
 [[package]]
 name = "postgres-protocol"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4888a0e36637ab38d76cace88c1476937d617ad015f07f6b669cec11beacc019"
+checksum = "ff3e0f70d32e20923cabf2df02913be7c1842d4c772db8065c00fcfdd1d1bff3"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "hmac",
- "md5",
+ "md-5",
  "memchr",
- "rand 0.7.3",
+ "rand 0.8.4",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc08a7d94a80665de4a83942fa8db2fdeaf2f123fc0535e384dc4fff251efae"
+checksum = "430f4131e1b7657b0cd9a2b0c3408d77c9a43a042d300b8c77f981dffcc43a2f"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "postgres-protocol",
 ]
@@ -1200,7 +1377,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1209,11 +1386,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1237,6 +1426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,7 +1456,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -1279,6 +1487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,7 +1512,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1309,7 +1526,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1370,17 +1587,17 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.10.10"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64 0.13.0",
- "bytes",
+ "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1395,19 +1612,29 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "pin-project-lite 0.2.1",
+ "pin-project-lite",
  "rustls",
  "serde",
  "serde_json",
- "serde_urlencoded 0.7.0",
+ "serde_urlencoded",
  "tokio",
  "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
- "winreg",
+ "webpki-roots 0.21.1",
+ "winreg 0.7.0",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -1422,7 +1649,7 @@ dependencies = [
  "spin 0.5.2",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1436,16 +1663,22 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
  "webpki",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1498,18 +1731,27 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.118"
+name = "serde_bytes"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1522,21 +1764,10 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url",
 ]
 
 [[package]]
@@ -1552,6 +1783,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edeeaecd5445109b937a3a335dc52780ca7779c4b4b7374cc6340dedfe44cfca"
+dependencies = [
+ "rustversion",
+ "serde",
+ "serde_with_macros",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48b35457e9d855d3dc05ef32a73e0df1e2c0fd72c38796a4ee909160c8eeec2"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serenity"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,7 +1815,7 @@ dependencies = [
  "async-tungstenite",
  "base64 0.13.0",
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "chrono",
  "flate2",
  "futures",
@@ -1590,26 +1844,26 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -1649,7 +1903,17 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1695,6 +1959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,14 +1972,20 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
@@ -1722,7 +1998,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1736,18 +2012,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1771,14 +2047,14 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1791,33 +2067,29 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
+ "autocfg 1.0.1",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1826,62 +2098,73 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.5.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a2482c9fe4dd481723cf5c0616f34afc710e55dcda0944e12e7b3316117892"
+checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "fallible-iterator",
  "futures",
  "log",
  "parking_lot",
  "percent-encoding",
  "phf",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
+ "socket2 0.4.0",
  "tokio",
  "tokio-util",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.14.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
 dependencies = [
- "futures-core",
  "rustls",
  "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.11.0"
+name = "tokio-stream"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9e878ad426ca286e4dcae09cbd4e1973a7f8987d97570e2469703dd7f5720c"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 0.4.27",
+ "pin-project 1.0.3",
  "tokio",
- "tungstenite",
+ "tungstenite 0.12.0",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.3.1"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1899,7 +2182,7 @@ checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.2.1",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -1935,6 +2218,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "trust-dns-proto"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand 0.8.4",
+ "smallvec",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "trust-dns-proto",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,13 +2276,32 @@ checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
  "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
- "input_buffer",
+ "input_buffer 0.3.1",
  "log",
  "rand 0.7.3",
- "sha-1 0.9.2",
+ "sha-1 0.9.6",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes 1.0.1",
+ "http",
+ "httparse",
+ "input_buffer 0.4.0",
+ "log",
+ "rand 0.8.4",
+ "sha-1 0.9.6",
  "url",
  "utf-8",
 ]
@@ -1966,6 +2313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345426c7406aa355b60c5007c79a2d1f5b605540072795222f17f6443e6a9c6f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2008,6 +2366,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2032,16 +2396,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
-
-[[package]]
 name = "utf-8"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.3",
+ "serde",
+]
 
 [[package]]
 name = "version_check"
@@ -2061,11 +2429,11 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
+checksum = "332d47745e9a0c38636dbd454729b147d16bd1ed08ae67b3ab281c4506771054"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures",
  "headers",
  "http",
@@ -2074,17 +2442,18 @@ dependencies = [
  "mime",
  "mime_guess",
  "multipart",
- "pin-project 0.4.27",
+ "percent-encoding",
+ "pin-project 1.0.3",
  "scoped-tls",
  "serde",
  "serde_json",
- "serde_urlencoded 0.6.1",
+ "serde_urlencoded",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
+ "tokio-util",
  "tower-service",
  "tracing",
- "tracing-futures",
- "urlencoding",
 ]
 
 [[package]]
@@ -2197,10 +2566,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.2.8"
+name = "webpki-roots"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
+checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "widestring"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
@@ -2211,12 +2589,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -2230,7 +2602,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2241,21 +2613,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde"] }
 
 regex = "1.4"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,16 +12,15 @@ reqwest = { version = "0.11", features = ["rustls-tls", "json"], default-feature
 futures = "0.3"
 
 tokio-postgres = "0.7"
-
-mongodb = { version = "2.0.0-beta.1", features = ["bson-uuid-0_8"] }
-bson = { version = "2.0.0-beta.1", features = ["uuid-0_8"] }
+chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.5"
 
 byteorder = "1.3"
 bytes = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-uuid = { version = "0.8", features = ["serde"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 regex = "1.4"
 lazy_static = "1.4"
@@ -35,3 +34,8 @@ thiserror = "1.0"
 
 log = "0.4"
 env_logger = "0.7.1"
+
+# The latest release on crates.io doesn't have support for serialising DateTime
+[dependencies.clickhouse-rs]
+git = "https://github.com/suharev7/clickhouse-rs"
+branch = "async-await"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,29 +5,34 @@ authors = ["Gegy <gegy1000@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2", features = ["full"] }
-tokio-util = { version = "0.3", features = ["codec"] }
-warp = "0.2"
-reqwest = { version = "0.10", features = ["rustls-tls", "json"], default-features = false }
+tokio = { version = "1.0", features = ["full"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+warp = "0.3"
+reqwest = { version = "0.11", features = ["rustls-tls", "json"], default-features = false }
 futures = "0.3"
 
-tokio-postgres = "0.5"
+tokio-postgres = "0.7"
+
+mongodb = { version = "2.0.0-beta.1", features = ["bson-uuid-0_8"] }
+bson = { version = "2.0.0-beta.1", features = ["uuid-0_8"] }
 
 byteorder = "1.3"
-bytes = "0.5"
+bytes = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+uuid = { version = "0.8", features = ["serde"] }
 
 regex = "1.4"
 lazy_static = "1.4"
 
-serenity = { version = "0.10", default-features = false, features = ["builder", "cache", "client", "gateway", "model", "http", "rustls_tokio_0_2_backend"] }
+serenity = { version = "0.10", default-features = false, features = ["builder", "cache", "client", "gateway", "model", "http", "rustls_backend"] }
 async-trait = "0.1"
 
 xtra = "0.5.0-rc.1"
 
 thiserror = "1.0"
+anyhow = "1.0"
 
 log = "0.4"
 env_logger = "0.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ async-trait = "0.1"
 xtra = "0.5.0-rc.1"
 
 thiserror = "1.0"
-anyhow = "1.0"
 
 log = "0.4"
 env_logger = "0.7.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub database: Option<DatabaseConfig>,
     #[serde(default = "HashMap::new")]
     pub kickbacks: HashMap<String, Kickback>,
+    pub statistics: Option<StatisticsConfig>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -22,11 +23,20 @@ pub struct DiscordConfig {
     pub relay_channel_topic: bool,
     #[serde(default)]
     pub player_avatar_url: Option<String>,
+    #[serde(default)]
+    pub error_webhook: Option<ErrorWebhookConfig>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ErrorWebhookConfig {
+    pub id: u64,
+    pub token: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct WebServerConfig {
     pub port: u16,
+    pub server_tokens: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -48,6 +58,12 @@ pub struct Kickback {
     pub to_server: String,
     pub from_server: String,
     pub proxy_channel: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StatisticsConfig {
+    pub database_url: String,
+    pub database_name: String,
 }
 
 pub(super) fn load() -> Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,7 +36,6 @@ pub struct ErrorWebhookConfig {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct WebServerConfig {
     pub port: u16,
-    pub server_tokens: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -10,6 +10,7 @@ use crate::discord::{self, DiscordClient, ReportError};
 use crate::integrations::{self, IntegrationsClient};
 use crate::model::*;
 use crate::statistics::database::{StatisticDatabaseController, UploadStatsBundle};
+use uuid::Uuid;
 
 // TODO: use numerical channel ids internally?
 pub struct Controller {
@@ -440,9 +441,11 @@ impl Handler<BackendError> for Controller {
 
 #[async_trait]
 impl Handler<UploadStatsBundle> for Controller {
-    async fn handle(&mut self, message: UploadStatsBundle, _ctx: &mut Context<Self>) {
+    async fn handle(&mut self, message: UploadStatsBundle, _ctx: &mut Context<Self>) -> <UploadStatsBundle as Message>::Result {
         if let Some(statistics) = &self.statistics {
-            let _ = statistics.do_send_async(message).await;
+            statistics.send(message).await.expect("statistics controller disconnected")
+        } else {
+            Uuid::nil()
         }
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -10,7 +10,6 @@ use crate::discord::{self, DiscordClient, ReportError};
 use crate::integrations::{self, IntegrationsClient};
 use crate::model::*;
 use crate::statistics::database::{StatisticDatabaseController, UploadStatsBundle};
-use uuid::Uuid;
 
 // TODO: use numerical channel ids internally?
 pub struct Controller {
@@ -444,8 +443,6 @@ impl Handler<UploadStatsBundle> for Controller {
     async fn handle(&mut self, message: UploadStatsBundle, _ctx: &mut Context<Self>) -> <UploadStatsBundle as Message>::Result {
         if let Some(statistics) = &self.statistics {
             statistics.send(message).await.expect("statistics controller disconnected")
-        } else {
-            Uuid::nil()
         }
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -9,7 +9,7 @@ use crate::database::{self, DatabaseClient};
 use crate::discord::{self, DiscordClient, ReportError};
 use crate::integrations::{self, IntegrationsClient};
 use crate::model::*;
-use crate::statistics::database::StatisticDatabaseController;
+use crate::statistics::database::{StatisticDatabaseController, UploadStatsBundle};
 
 // TODO: use numerical channel ids internally?
 pub struct Controller {
@@ -434,6 +434,15 @@ impl Handler<BackendError> for Controller {
                 description: message.description,
                 fields: message.fields,
             }).await;
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<UploadStatsBundle> for Controller {
+    async fn handle(&mut self, message: UploadStatsBundle, _ctx: &mut Context<Self>) {
+        if let Some(statistics) = &self.statistics {
+            let _ = statistics.do_send_async(message).await;
         }
     }
 }

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -399,26 +399,6 @@ impl Handler<ReportError> for DiscordClient {
                 warn!("Invalid error reporting webhook config!");
             }
         }
-        // let mut webhook = http.get_webhook_with_token(id, token).await?;
-        //
-        // let embed = Embed::fake(|mut e| {
-        //     e.title("Rust's website");
-        //     e.description("Rust is a systems programming language that runs
-        //                    blazingly fast, prevents segfaults, and guarantees
-        //                    thread safety.");
-        //     e.url("https://rust-lang.org");
-        //     e
-        // });
-        //
-        // webhook.execute(&http, false, |mut w| {
-        //     w.content("test");
-        //     w.username("serenity");
-        //     w.embeds(vec![embed]);
-        //     w
-        // })
-        // .await?;
-
-
     }
 }
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use serenity::CacheAndHttp;
 use serenity::client::bridge::gateway::GatewayIntents;
 use serenity::client::Context as SerenityContext;
-use serenity::model::channel::{Channel, Message as SerenityMessage, ReactionType};
+use serenity::model::channel::{Channel, Message as SerenityMessage, ReactionType, Embed};
 use serenity::model::id::{ChannelId, RoleId};
 use serenity::model::webhook::Webhook;
 use serenity::prelude::*;
@@ -223,6 +223,16 @@ impl XtraMessage for UpdateRelayStatus {
     type Result = ();
 }
 
+pub struct ReportError {
+    pub title: String,
+    pub description: String,
+    pub fields: Option<HashMap<String, String>>,
+}
+
+impl XtraMessage for ReportError {
+    type Result = ();
+}
+
 #[async_trait]
 impl Handler<Init> for DiscordClient {
     async fn handle(&mut self, message: Init, _ctx: &mut XtraContext<Self>) {
@@ -359,6 +369,56 @@ impl Handler<UpdateRelayStatus> for DiscordClient {
                 }
             }
         }
+    }
+}
+
+#[async_trait]
+impl Handler<ReportError> for DiscordClient {
+    async fn handle(&mut self, message: ReportError, _ctx: &mut XtraContext<Self>) {
+        if let (Some(cache_and_http), Some(webhook_config)) = (&self.cache_and_http, &self.config.error_webhook) {
+            if let Ok(webhook) = &cache_and_http.http.get_webhook_with_token(webhook_config.id, &*webhook_config.token).await {
+                let embed = Embed::fake(|e| {
+                    e.title(message.title);
+                    e.description(message.description);
+                    if let Some(fields) = message.fields {
+                        for (name, value) in fields {
+                            e.field(name, value, false);
+                        }
+                    }
+                    e
+                });
+
+                if let Err(e) = webhook.execute(&cache_and_http.http, false, |w| {
+                    w.embeds(vec![embed]);
+                    w.username("Backend error reporting");
+                    w
+                }).await {
+                    warn!("Failed to report error to discord: {}", e);
+                }
+            } else {
+                warn!("Invalid error reporting webhook config!");
+            }
+        }
+        // let mut webhook = http.get_webhook_with_token(id, token).await?;
+        //
+        // let embed = Embed::fake(|mut e| {
+        //     e.title("Rust's website");
+        //     e.description("Rust is a systems programming language that runs
+        //                    blazingly fast, prevents segfaults, and guarantees
+        //                    thread safety.");
+        //     e.url("https://rust-lang.org");
+        //     e
+        // });
+        //
+        // webhook.execute(&http, false, |mut w| {
+        //     w.content("test");
+        //     w.username("serenity");
+        //     w.embeds(vec![embed]);
+        //     w
+        // })
+        // .await?;
+
+
     }
 }
 

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -166,11 +166,6 @@ pub enum OutgoingMessage {
         from_server: String,
         to_server: String,
     },
-    #[serde(rename = "upload_statistics_response")]
-    UploadStatisticsResponse {
-        message_id: i32,
-        game_id: Uuid,
-    }
 }
 
 impl Message for OutgoingMessage {
@@ -229,20 +224,7 @@ impl Handler<HandleIncomingMessage> for IntegrationsClient {
                                 self.channel, bundle.stats.players.len(), bundle.namespace);
                         }
                         let upload_bundle_message = UploadStatsBundle(self.channel.clone(), bundle);
-                        let res = self.controller.send(upload_bundle_message).await;
-                        match res {
-                            Ok(game_id) => {
-                                let addr = ctx.address().unwrap().clone();
-                                addr.do_send_async(OutgoingMessage::UploadStatisticsResponse {
-                                    message_id,
-                                    game_id,
-                                }).await.unwrap();
-                                Ok(())
-                            },
-                            Err(e) => {
-                                Err(e)
-                            }
-                        }
+                        self.controller.do_send_async(upload_bundle_message).await
                     }
                     _ => {
                         warn!("received unexpected message from integrations client: {:?}", message);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ mod persistent;
 mod config;
 mod database;
 mod statistics;
-mod util;
 
 pub struct TokioGlobal;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ mod controller;
 mod persistent;
 mod config;
 mod database;
+mod statistics;
+mod util;
 
 pub struct TokioGlobal;
 
@@ -33,11 +35,15 @@ async fn main() {
         .create(None)
         .spawn(&mut TokioGlobal);
 
-    let mut futures = Vec::with_capacity(3);
+    let mut futures = Vec::with_capacity(5);
 
     if let Some(integrations) = config.integrations {
         futures.push(tokio::spawn(integrations::run(controller.clone(), integrations)));
     }
+
+    if let Some(statistics) = config.statistics {
+        futures.push(tokio::spawn(statistics::run(controller.clone(), statistics)));
+    };
 
     if let Some(web) = config.web_server {
         futures.push(tokio::spawn(web::run(controller.clone(), web)));
@@ -48,7 +54,7 @@ async fn main() {
     }
 
     if let Some(database) = config.database {
-        futures.push(tokio::spawn(database::run(controller.clone(), database)))
+        futures.push(tokio::spawn(database::run(controller.clone(), database)));
     }
 
     let _ = futures::future::join_all(futures).await;

--- a/src/persistent.rs
+++ b/src/persistent.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use serde::{de::DeserializeOwned, Serialize};
 use tokio::fs::File;
-use tokio::prelude::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 pub trait Persistable: Serialize + DeserializeOwned + Default {}
 

--- a/src/statistics/database.rs
+++ b/src/statistics/database.rs
@@ -1,0 +1,337 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use mongodb::{bson::doc, Client, Collection, Database};
+use mongodb::options::FindOptions;
+use uuid::Uuid;
+use xtra::{Actor, Context, Handler, Message, Address};
+
+use crate::util::uuid_to_bson;
+use std::collections::HashMap;
+use bson::Document;
+use crate::statistics::model::{PlayerProfile, PlayerGameStats, GlobalGameStats, PlayerStatsResponse, GameStatsBundle};
+use crate::{StatisticsConfig, Controller, BackendError};
+
+const CORRUPT_STATS_DESCRIPTION: &str = r#"
+The backend detected an invalid statistic document while uploading a bundle.
+It is likely a minigame has changed the type of one of its stored statistics.
+The affected document(s) have been backed up and removed from the database.
+"#;
+
+pub struct StatisticDatabaseController {
+    controller: Address<Controller>,
+    client: Client,
+    config: StatisticsConfig,
+}
+
+impl StatisticDatabaseController {
+    pub async fn connect(controller: &Address<Controller>, config: &StatisticsConfig) -> Result<Self> {
+        let handler = Self {
+            controller: controller.clone(),
+            client: Client::with_uri_str(&*config.database_url).await?,
+            config: config.clone(),
+        };
+
+        // Ping the database to ensure we can connect and so we crash early if we can't
+        handler.client.database("admin")
+            .run_command(doc! {"ping": 1}, None)
+            .await?;
+
+        Ok(handler)
+    }
+
+    fn database(&self) -> Database {
+        self.client.database(&*self.config.database_name)
+    }
+
+    fn player_profiles(&self) -> Collection<PlayerProfile> {
+        self.database().collection("players")
+    }
+
+    fn player_stats(&self) -> Collection<PlayerGameStats> {
+        self.database().collection("player-stats")
+    }
+
+    fn global_stats(&self) -> Collection<GlobalGameStats> {
+        self.database().collection("global-stats")
+    }
+
+    // Used for error handling
+    fn document_player_stats(&self) -> Collection<Document> {
+        self.database().collection("player-stats")
+    }
+
+    fn document_global_stats(&self) -> Collection<Document> {
+        self.database().collection("global-stats")
+    }
+
+    fn corrupt_stats(&self) -> Collection<Document> {
+        self.database().collection("corrupt_stats")
+    }
+
+    async fn get_player_profile(&self, uuid: &Uuid) -> Result<Option<PlayerProfile>> {
+        let options = FindOptions::builder().limit(1).build();
+        let profile = self.player_profiles()
+            .find(doc! {"uuid": uuid_to_bson(uuid)?}, options).await?
+            .try_next().await?;
+        Ok(profile)
+    }
+
+    async fn update_player_profile(&self, uuid: &Uuid, username: Option<String>) -> Result<PlayerProfile> {
+        match self.get_player_profile(uuid).await? {
+            Some(profile) => {
+                if let Some(username) = username {
+                    if let Some(profile_username) = profile.username.clone() {
+                        if username != profile_username {
+                            log::debug!("Player {} updated username to {}", uuid, &username);
+                            self.player_profiles().update_one(
+                                doc! {"uuid": uuid_to_bson(uuid)?},
+                                doc! {"$set": {
+                                    "username": username.clone(),
+                                }},
+                                None,
+                            ).await?;
+
+                            let mut profile = profile.clone();
+                            profile.username = Some(username.clone());
+                            return Ok(profile);
+                        }
+                    }
+                }
+                Ok(profile.clone())
+            }
+            None => {
+                let profile = PlayerProfile {
+                    uuid: *uuid,
+                    username: username.clone(),
+                };
+                self.player_profiles().insert_one(&profile, None).await?;
+                Ok(profile)
+            }
+        }
+    }
+
+    async fn get_player_stats(&self, uuid: &Uuid, namespace: &Option<String>) -> Result<Option<PlayerStatsResponse>> {
+        if self.get_player_profile(uuid).await?.is_none() { // player not found.
+            return Ok(None);
+        }
+
+        let options = FindOptions::builder().build();
+        let mut stats = self.player_stats().find(match namespace {
+            Some(namespace) => doc! {
+                "uuid": uuid_to_bson(uuid)?,
+                "namespace": namespace.clone(),
+            },
+            None => doc! {
+                "uuid": uuid_to_bson(uuid)?,
+            },
+        }, options).await?;
+
+        let mut final_stats: HashMap<String, HashMap<String, f64>> = HashMap::new();
+        while let Some(stats) = stats.try_next().await? {
+            let mut s = HashMap::new();
+            for (name, stat) in stats.stats {
+                s.insert(name, stat.into());
+            }
+            final_stats.insert(stats.namespace, s);
+        }
+
+        Ok(Some(final_stats))
+    }
+
+    async fn ensure_player_stats_document(&self, uuid: &Uuid, namespace: &str) -> Result<()> {
+        self.update_player_profile(uuid, None).await?; // Ensure that the player is tracked in the database.
+
+        let options = FindOptions::builder().limit(1).build();
+        let mut res = self.player_stats().find(doc! {
+            "uuid": uuid_to_bson(uuid)?,
+            "namespace": namespace,
+        }, options).await?;
+        let stats = res.try_next().await;
+
+        let needs_new_document = match stats {
+            Ok(stats) => stats.is_none(),
+            Err(e) => {
+                self.handle_broken_player_stats_document(&e.into(), uuid, namespace).await?;
+                true
+            }
+        };
+
+        if needs_new_document {
+            self.player_stats().insert_one(PlayerGameStats {
+                uuid: *uuid,
+                namespace: namespace.to_string(),
+                stats: HashMap::new(),
+            }, None).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn ensure_global_stats_document(&self, namespace: &str) -> Result<()> {
+        let options = FindOptions::builder().limit(1).build();
+        let mut res = self.global_stats().find(doc! {
+            "namespace": namespace,
+        }, options).await?;
+
+        let stats = res.try_next().await;
+
+        let needs_new_document = match stats {
+            Ok(stats) => stats.is_none(),
+            Err(e) => {
+                self.handle_broken_global_stats_document(&e.into(), &namespace).await?;
+                true
+            }
+        };
+
+        if needs_new_document {
+            self.global_stats().insert_one(GlobalGameStats {
+                namespace: namespace.to_string(),
+                stats: HashMap::new(),
+            }, None).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn upload_stats_bundle(&self, bundle: GameStatsBundle) -> Result<()> {
+        for (player, stats) in bundle.stats.players {
+            // Ensure that there is a document to upload stats to.
+            self.ensure_player_stats_document(&player, &bundle.namespace).await?;
+            for (stat_name, stat) in stats {
+                self.player_stats().update_one(doc! {
+                    "uuid": uuid_to_bson(&player)?,
+                    "namespace": &bundle.namespace,
+                }, stat.create_increment_operation(&stat_name), None).await?;
+            }
+        }
+
+        if let Some(global) = bundle.stats.global {
+            self.ensure_global_stats_document(&bundle.namespace).await?;
+            for (stat_name, stat) in global {
+                self.global_stats().update_one(doc! {
+                    "namespace": &bundle.namespace,
+                }, stat.create_increment_operation(&stat_name), None).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn handle_broken_player_stats_document(&self, e: &anyhow::Error, uuid: &Uuid, namespace: &str) -> Result<()> {
+        let doc = self.document_player_stats().find_one(doc! {
+            "uuid": uuid_to_bson(uuid)?,
+            "namespace": namespace,
+        }, None).await?;
+
+        if let Some(doc) = doc {
+            self.handle_broken_document(e, &doc, namespace, false).await?;
+            self.document_player_stats().delete_one(doc! {
+                "_id": doc.get("_id").unwrap(),
+            }, None).await?;
+        } else {
+            // This should never happen
+            log::warn!("Missing corrupt document that was there before!? (player: {}, namespace: {})", uuid, namespace);
+        }
+
+        Ok(())
+    }
+
+    async fn handle_broken_global_stats_document(&self, e: &anyhow::Error, namespace: &str) -> Result<()> {
+        let doc = self.document_global_stats().find_one(doc! {
+            "namespace": namespace,
+        }, None).await?;
+
+        if let Some(doc) = doc {
+            self.handle_broken_document(e, &doc, namespace, true).await?;
+            self.document_global_stats().delete_one(doc! {
+                "_id": doc.get("_id").unwrap(),
+            }, None).await?;
+        } else {
+            // This should never happen
+            log::warn!("Missing corrupt document that was there before!? (global; namespace: {})", namespace);
+        }
+
+        Ok(())
+    }
+
+    async fn handle_broken_document(&self, e: &anyhow::Error, document: &Document, namespace: &str, global: bool) -> Result<()> {
+        let mut corrupt_document = document.clone();
+        corrupt_document.remove("_id"); // remove the ID so the driver generates a new one when it is re-inserted
+        let corrupt_id = self.corrupt_stats().insert_one(document, None).await?.inserted_id;
+
+        log::warn!("Corrupt stats document (not our fault, probably a minigame's)!\nError: {}\nDocument: {}\nNamespace: {}, global: {}", e, document, namespace, global);
+        let mut warning_fields: HashMap<String, String> = HashMap::new();
+        warning_fields.insert("Statistic namespace".to_string(), namespace.to_string());
+        warning_fields.insert("Global statistic?".to_string(), global.to_string());
+        warning_fields.insert("Document backup ID".to_string(), corrupt_id.to_string());
+
+        self.controller.send(BackendError {
+            title: ":warning: Corrupt stats document".to_string(),
+            description: CORRUPT_STATS_DESCRIPTION.to_string(),
+            fields: Some(warning_fields),
+        }).await.expect("controller disconnected");
+
+        Ok(())
+    }
+}
+
+impl Actor for StatisticDatabaseController {}
+
+pub struct GetPlayerProfile(pub Uuid);
+impl Message for GetPlayerProfile {
+    type Result = Result<Option<PlayerProfile>>;
+}
+
+#[async_trait]
+impl Handler<GetPlayerProfile> for StatisticDatabaseController {
+    async fn handle(&mut self, message: GetPlayerProfile, _ctx: &mut Context<Self>) -> <GetPlayerProfile as Message>::Result {
+        self.get_player_profile(&message.0).await
+    }
+}
+
+pub struct UpdatePlayerProfile {
+    pub uuid: Uuid,
+    pub username: String,
+}
+
+impl Message for UpdatePlayerProfile {
+    type Result = Result<()>;
+}
+
+#[async_trait]
+impl Handler<UpdatePlayerProfile> for StatisticDatabaseController {
+    async fn handle(&mut self, message: UpdatePlayerProfile, _ctx: &mut Context<Self>) -> <UpdatePlayerProfile as Message>::Result {
+        self.update_player_profile(&message.uuid, Some(message.username)).await?;
+        Ok(())
+    }
+}
+
+pub struct GetPlayerStats {
+    pub uuid: Uuid,
+    pub namespace: Option<String>,
+}
+
+impl Message for GetPlayerStats {
+    type Result = Result<Option<PlayerStatsResponse>>;
+}
+
+#[async_trait]
+impl Handler<GetPlayerStats> for StatisticDatabaseController {
+    async fn handle(&mut self, message: GetPlayerStats, _ctx: &mut Context<Self>) -> <GetPlayerStats as Message>::Result {
+        self.get_player_stats(&message.uuid, &message.namespace).await
+    }
+}
+
+pub struct UploadStatsBundle(pub GameStatsBundle);
+
+impl Message for UploadStatsBundle {
+    type Result = Result<()>;
+}
+
+#[async_trait]
+impl Handler<UploadStatsBundle> for StatisticDatabaseController {
+    async fn handle(&mut self, message: UploadStatsBundle, _ctx: &mut Context<Self>) -> <UploadStatsBundle as Message>::Result {
+        self.upload_stats_bundle(message.0).await
+    }
+}

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,0 +1,16 @@
+use xtra::{Address, Actor};
+use crate::{Controller, StatisticsConfig, TokioGlobal, RegisterStatisticsDatabaseController};
+use crate::statistics::database::StatisticDatabaseController;
+
+pub mod model;
+pub mod database;
+
+pub async fn run(controller: Address<Controller>, config: StatisticsConfig) {
+    let statistics_database = StatisticDatabaseController::connect(&controller, &config).await
+        .expect("failed to connect to statistics database")
+        .create(None)
+        .spawn(&mut TokioGlobal);
+
+    controller.do_send_async(RegisterStatisticsDatabaseController { controller: statistics_database })
+        .await.expect("controller disconnected");
+}

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,5 +1,6 @@
-use xtra::{Address, Actor};
-use crate::{Controller, StatisticsConfig, TokioGlobal, RegisterStatisticsDatabaseController};
+use xtra::{Actor, Address};
+
+use crate::{Controller, RegisterStatisticsDatabaseController, StatisticsConfig, TokioGlobal};
 use crate::statistics::database::StatisticDatabaseController;
 
 pub mod model;

--- a/src/statistics/model.rs
+++ b/src/statistics/model.rs
@@ -48,19 +48,23 @@ pub enum GameStat {
         total: i32,
         count: i32,
     },
+    IntMin(i32),
+    IntMax(i32),
     FloatTotal(f64),
     FloatRollingAverage {
         total: f64,
         count: i32,
     },
+    FloatMin(f64),
+    FloatMax(f64),
 }
 
 impl Into<f64> for GameStat {
     fn into(self) -> f64 {
         match self {
-            GameStat::IntTotal(v) => v as f64,
+            GameStat::IntTotal(v) | GameStat::IntMin(v) | GameStat::IntMax(v) => v as f64,
             GameStat::IntRollingAverage { total, count } => (total as f64) / (count as f64),
-            GameStat::FloatTotal(v) => v,
+            GameStat::FloatTotal(v) | GameStat::FloatMin(v) | GameStat::FloatMax(v) => v,
             GameStat::FloatRollingAverage { total, count } => total / (count as f64),
         }
     }
@@ -91,8 +95,12 @@ pub struct StatsBundle {
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum UploadStat {
     IntTotal(i32),
+    IntMin(i32),
+    IntMax(i32),
     IntRollingAverage(i32),
     FloatTotal(f64),
+    FloatMin(f64),
+    FloatMax(f64),
     FloatRollingAverage(f64),
 }
 

--- a/src/statistics/model.rs
+++ b/src/statistics/model.rs
@@ -75,20 +75,19 @@ pub struct GlobalStatsBundle {
 pub type PlayerStatsResponse = HashMap<String, HashMap<String, f64>>;
 pub type PlayerStatsBundle = HashMap<Uuid, HashMap<String, UploadStat>>;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GameStatsBundle {
-    pub server_name: String,
     pub namespace: String,
     pub stats: StatsBundle,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct StatsBundle {
     pub global: Option<HashMap<String, UploadStat>>,
     pub players: PlayerStatsBundle,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum UploadStat {
     IntTotal(i32),

--- a/src/statistics/model.rs
+++ b/src/statistics/model.rs
@@ -1,0 +1,127 @@
+use serde::{Serialize, Deserialize};
+use uuid::Uuid;
+use bson::{Document, doc};
+use std::collections::HashMap;
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PlayerProfile {
+    #[serde(with = "bson::serde_helpers::uuid_as_binary")]
+    pub uuid: Uuid,
+    pub username: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PlayerProfileResponse {
+    pub uuid: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+}
+
+impl From<PlayerProfile> for PlayerProfileResponse {
+    fn from(p: PlayerProfile) -> Self {
+        Self {
+            uuid: p.uuid,
+            username: p.username,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PlayerGameStats {
+    #[serde(with = "bson::serde_helpers::uuid_as_binary")]
+    pub uuid: Uuid,
+    pub namespace: String,
+    pub stats: HashMap<String, GameStat>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GlobalGameStats {
+    pub namespace: String,
+    pub stats: HashMap<String, GameStat>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum GameStat {
+    IntTotal(i32),
+    IntRollingAverage {
+        total: i32,
+        count: i32,
+    },
+    FloatTotal(f64),
+    FloatRollingAverage {
+        total: f64,
+        count: i32,
+    },
+}
+
+impl Into<f64> for GameStat {
+    fn into(self) -> f64 {
+        match self {
+            GameStat::IntTotal(v) => v as f64,
+            GameStat::IntRollingAverage { total, count } => (total as f64) / (count as f64),
+            GameStat::FloatTotal(v) => v,
+            GameStat::FloatRollingAverage { total, count } => total / (count as f64),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GlobalStatsBundle {
+    pub namespace: String,
+    pub stats: HashMap<String, GameStat>,
+}
+
+pub type PlayerStatsResponse = HashMap<String, HashMap<String, f64>>;
+pub type PlayerStatsBundle = HashMap<Uuid, HashMap<String, UploadStat>>;
+
+#[derive(Serialize, Deserialize)]
+pub struct GameStatsBundle {
+    pub server_name: String,
+    pub namespace: String,
+    pub stats: StatsBundle,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct StatsBundle {
+    pub global: Option<HashMap<String, UploadStat>>,
+    pub players: PlayerStatsBundle,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
+pub enum UploadStat {
+    IntTotal(i32),
+    IntRollingAverage(i32),
+    FloatTotal(f64),
+    FloatRollingAverage(f64),
+}
+
+impl UploadStat {
+    /// Generate a BSON document for increasing this value.
+    pub fn create_increment_operation(&self, id: &str) -> Document {
+        let value_key = format!("stats.{}.value", id);
+        let type_key = format!("stats.{}.type", id);
+        let total_key = format!("{}.total", value_key);
+        let count_key = format!("{}.count", value_key);
+
+        match self {
+            UploadStat::IntTotal(value) => doc! {
+                "$inc": { value_key: value },
+                "$set": { type_key: "int_total" }
+            },
+            UploadStat::IntRollingAverage(value) => doc! {
+                "$inc": { total_key: value, count_key: 1 },
+                "$set": { type_key: "int_rolling_average" }
+            },
+            UploadStat::FloatTotal(value) => doc! {
+                "$inc": { value_key: value },
+                "$set": { type_key: "float_total" }
+            },
+            UploadStat::FloatRollingAverage(value) => doc! {
+                "$inc": { total_key: value, count_key: 1 },
+                "$set": { type_key: "float_rolling_average" }
+            },
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,7 @@
+use uuid::Uuid;
+use bson::Bson;
+
+pub fn uuid_to_bson(uuid: &Uuid) -> bson::ser::Result<Bson> {
+    let serializer = bson::ser::Serializer::new();
+    bson::serde_helpers::uuid_as_binary::serialize(uuid, serializer)
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,0 @@
-use uuid::Uuid;
-use bson::Bson;
-
-pub fn uuid_to_bson(uuid: &Uuid) -> bson::ser::Result<Bson> {
-    let serializer = bson::ser::Serializer::new();
-    bson::serde_helpers::uuid_as_binary::serialize(uuid, serializer)
-}

--- a/src/web.rs
+++ b/src/web.rs
@@ -84,7 +84,7 @@ async fn get_player_stats(controller: Address<Controller>, uuid: Uuid, namespace
     }
 }
 
-fn handle_server_error(e: &anyhow::Error) -> Box<dyn warp::Reply> {
+fn handle_server_error(e: &mongodb::error::Error) -> Box<dyn warp::Reply> {
     log::warn!("error handling request: {}", e);
     send_http_status(StatusCode::INTERNAL_SERVER_ERROR)
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -1,9 +1,12 @@
+use uuid::Uuid;
 use warp::Filter;
 use warp::http::StatusCode;
 use xtra::prelude::*;
 
-use crate::WebServerConfig;
 use crate::controller::*;
+use crate::statistics::database::{UploadStatsBundle, GetPlayerStats};
+use crate::statistics::model::GameStatsBundle;
+use crate::WebServerConfig;
 
 pub async fn run(controller: Address<Controller>, config: WebServerConfig) {
     let cors = warp::cors()
@@ -14,14 +17,48 @@ pub async fn run(controller: Address<Controller>, config: WebServerConfig) {
         .and_then({
             let controller = controller.clone();
             move |channel| get_status(controller.clone(), channel)
+        }).with(&cors);
+
+    let player_game_stats = warp::path("player")
+        .and(warp::path::param::<Uuid>())
+        .and(warp::path("stats"))
+        .and(warp::path::param::<String>())
+        .and_then({
+            let controller = controller.clone();
+            move |uuid, namespace| get_player_stats(controller.clone(), uuid, Some(namespace))
+        }).with(&cors);
+
+    let all_player_game_stats = warp::path("player")
+        .and(warp::path::param::<Uuid>())
+        .and(warp::path("stats"))
+        .and_then({
+            let controller = controller.clone();
+            move |uuid| get_player_stats(controller.clone(), uuid, None)
+        }).with(&cors);
+
+    let upload_game_stats = warp::path("stats")
+        .and(warp::path("upload"))
+        .and(warp::filters::method::post())
+        .and(warp::header("Authorization"))
+        .and(warp::filters::body::json())
+        .and_then({
+            let config = config.clone();
+            let controller = controller.clone();
+            move |authorization, game_stats: GameStatsBundle|
+                upload_game_stats(config.clone(), controller.clone(), authorization, game_stats)
         });
 
-    warp::serve(status.with(cors))
+    let combined = status
+        .or(player_game_stats)
+        .or(all_player_game_stats)
+        .or(upload_game_stats);
+
+    warp::serve(combined)
         .run(([127, 0, 0, 1], config.port))
         .await;
 }
 
-async fn get_status(controller: Address<Controller>, channel: String) -> Result<Box<dyn warp::Reply>, warp::Rejection> {
+async fn get_status(controller: Address<Controller>, channel: String) -> ApiResult {
     match controller.send(GetStatus(channel)).await {
         Ok(status) => {
             Ok(match status {
@@ -31,4 +68,82 @@ async fn get_status(controller: Address<Controller>, channel: String) -> Result<
         },
         Err(err) => Ok(Box::new(warp::reply::with_status(format!("{:?}", err), StatusCode::INTERNAL_SERVER_ERROR))),
     }
+}
+
+type ApiResult = Result<Box<dyn warp::Reply>, warp::Rejection>;
+
+async fn get_player_stats(controller: Address<Controller>, uuid: Uuid, namespace: Option<String>) -> ApiResult {
+    let statistics = if let Some(statistics) = controller.send(GetStatisticsDatabaseController)
+        .await.expect("controller disconnected") {
+        statistics
+    } else {
+        return Ok(send_http_status(StatusCode::NOT_FOUND));
+    };
+
+    let res = statistics.send(GetPlayerStats {
+        uuid,
+        namespace
+    }).await.unwrap();
+    return match res {
+        Ok(stats) => {
+            Ok(if let Some(stats) = stats {
+                Box::new(warp::reply::json(&stats))
+            } else {
+                send_http_status(StatusCode::NOT_FOUND)
+            })
+        },
+        Err(e) => {
+            Ok(handle_server_error(&e))
+        }
+    }
+}
+
+async fn upload_game_stats(config: WebServerConfig, controller: Address<Controller>, authorization: String, game_stats: GameStatsBundle) -> ApiResult {
+    let statistics = if let Some(statistics) = controller.send(GetStatisticsDatabaseController)
+        .await.expect("controller disconnected") {
+        statistics
+    } else {
+        return Ok(send_http_status(StatusCode::NOT_FOUND));
+    };
+
+    if !config.server_tokens.contains(&authorization) {
+        return Ok(send_http_status(StatusCode::UNAUTHORIZED))
+    }
+
+    if let Some(global) = &game_stats.stats.global {
+        log::debug!("server '{}' uploaded {} player statistics and {} global statistics in statistics bundle for {}",
+                game_stats.server_name, game_stats.stats.players.len(), global.len(), game_stats.namespace);
+
+        for name in global.keys() {
+            if name.contains('.') {
+                return Ok(send_http_status(StatusCode::BAD_REQUEST));
+            }
+        }
+    } else {
+        log::debug!("server '{}' uploaded {} player statistics in statistics bundle for {}",
+                game_stats.server_name, game_stats.stats.players.len(), game_stats.namespace);
+    }
+
+    for stats in game_stats.stats.players.values() {
+        for name in stats.keys() {
+            if name.contains('.') {
+                return Ok(send_http_status(StatusCode::BAD_REQUEST));
+            }
+        }
+    }
+
+    let res = statistics.send(UploadStatsBundle(game_stats)).await.unwrap();
+    match res {
+        Ok(()) => Ok(Box::new(warp::reply::with_status("", StatusCode::NO_CONTENT))),
+        Err(e) => Ok(handle_server_error(&e)),
+    }
+}
+
+fn handle_server_error(e: &anyhow::Error) -> Box<dyn warp::Reply> {
+    log::warn!("error handling request: {}", e);
+    send_http_status(StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+fn send_http_status(status: StatusCode) -> Box<dyn warp::Reply> {
+    Box::new(warp::reply::with_status(status.canonical_reason().unwrap_or(""), status))
 }


### PR DESCRIPTION
Based on [my standalone implementation](https://github.com/Tom-The-Geek/nucleoid-persistence-backend).

- Updates tokio to 1.0 (from 0.2) along with related dependencies
- Discord webhook-based error reporting currently used for reporting broken documents
- Adds endpoints to the web api for querying a players statistics