### PR TITLE
Recent games endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Backend service used for the Nucleoid Minecraft server.
 You can easily deploy the backend using [`docker-compose`](https://docs.docker.com/compose/) on a server using the provided `Dockerfile` and `docker-compose.yml`.
 
 You can clone the repository and run `docker-compose up` to start up the required databases and the backend itself. This will use the config file in `config/config.json`, where you can then further configure the backend, including things like the Discord integration.
+
+## Developing
+
+If you want to start up the two databases required to develop those components,
+then you can use the provided `docker-compose-dev.yml` file, which will start containers
+for both the postgres and ClickHouse databases:
+
+```bash
+docker-compose -f docker-compose-dev.yml up
+# or
+docker-compose -f docker-compose-dev.yml start
+```

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,7 @@
 {
     "web_server": {
-        "port": 1234
+        "port": 1234,
+        "max_query_size": 50
     },
     "integrations": {
         "port": 20000

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+     - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: nucleoid
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data
+  clickhouse:
+    image: yandex/clickhouse-server
+    ports:
+      - 8123:8123
+      - 9000:9000
+    environment:
+      CLICKHOUSE_DB: nucleoid
+    volumes:
+      - ./clickhouse_data:/var/lib/clickhouse

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,6 +36,7 @@ pub struct ErrorWebhookConfig {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct WebServerConfig {
     pub port: u16,
+    pub max_query_size: u32,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/statistics/database.rs
+++ b/src/statistics/database.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use clickhouse_rs::{Block, Pool, row};
 use log::warn;
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use xtra::{Actor, Address, Context, Handler, Message};
 
 use crate::{Controller, StatisticsConfig};
-use crate::statistics::model::{GameStatsBundle, initialise_database, PlayerStatsResponse};
+use crate::statistics::model::{GameStatsBundle, initialise_database, PlayerStatsResponse, RecentGame};
 
 pub struct StatisticDatabaseController {
     _controller: Address<Controller>,
@@ -18,7 +18,7 @@ pub struct StatisticDatabaseController {
 }
 
 impl StatisticDatabaseController {
-    pub async fn connect(controller: &Address<Controller>, config: &StatisticsConfig) -> Result<Self, StatisticsDatabaseError> {
+    pub async fn connect(controller: &Address<Controller>, config: &StatisticsConfig) -> StatisticsDatabaseResult<Self> {
         let handler = Self {
             _controller: controller.clone(),
             pool: Pool::new(config.database_url.clone()),
@@ -30,7 +30,7 @@ impl StatisticDatabaseController {
         Ok(handler)
     }
 
-    async fn get_player_stats(&self, player_id: &Uuid, namespace: &Option<String>) -> Result<Option<PlayerStatsResponse>, StatisticsDatabaseError> {
+    async fn get_player_stats(&self, player_id: &Uuid, namespace: &Option<String>) -> StatisticsDatabaseResult<Option<PlayerStatsResponse>> {
         let mut handle = self.pool.get_handle().await?;
 
         let cond = match namespace {
@@ -74,7 +74,59 @@ impl StatisticDatabaseController {
         }
     }
 
-    async fn get_game_stats(&self, game_id: &Uuid) -> Result<Option<HashMap<Uuid, PlayerStatsResponse>>, StatisticsDatabaseError> {
+    async fn get_recent_games(&self, limit: u32) -> StatisticsDatabaseResult<Vec<RecentGame>> {
+        let mut handle = self.pool.get_handle().await?;
+
+        let sql = format!(r#"
+        SELECT *
+        FROM games
+        ORDER BY date_played DESC
+        LIMIT {}
+        "#, limit);
+
+        let games_res = handle.query(sql).fetch_all().await?;
+
+        if games_res.is_empty() {
+            return Ok(Vec::with_capacity(0));
+        }
+
+        let mut games = Vec::new();
+
+        for row in games_res.rows() {
+            let game_id: Uuid = row.get("game_id")?;
+            let namespace: String = row.get("namespace")?;
+            let player_count: u32 = row.get("player_count")?;
+            let server: String = row.get("server")?;
+            let date_played: DateTime<Tz> = row.get("date_played")?;
+
+            let players_sql = format!(r#"
+            SELECT player_id
+            FROM player_statistics
+            WHERE game_id = '{}'
+            GROUP BY player_id
+            "#, game_id);
+
+            let players_res = handle.query(players_sql).fetch_all().await?;
+            let mut players = Vec::with_capacity(player_count as usize);
+            for player_id in players_res.rows().map(|row| row.get::<Uuid, _>("player_id")) {
+                players.push(player_id?);
+            }
+
+            games.push(RecentGame {
+                id: game_id,
+                namespace,
+                players,
+                server,
+                date_played: date_played.with_timezone(&Utc),
+            });
+        }
+
+        Ok(games)
+    }
+
+    // TODO: Query player's recent games
+
+    async fn get_game_stats(&self, game_id: &Uuid) -> StatisticsDatabaseResult<Option<HashMap<Uuid, PlayerStatsResponse>>> {
         let mut handle = self.pool.get_handle().await?;
 
         let game_sql = format!("SELECT game_id FROM games WHERE game_id = '{}'", game_id);
@@ -141,7 +193,7 @@ impl StatisticDatabaseController {
         Ok(Some(players))
     }
 
-    async fn upload_stats_bundle(&self, game_id: Uuid, server: &String, bundle: GameStatsBundle) -> Result<Uuid, StatisticsDatabaseError> {
+    async fn upload_stats_bundle(&self, game_id: Uuid, server: &String, bundle: GameStatsBundle) -> StatisticsDatabaseResult<Uuid> {
         let mut handle = self.pool.get_handle().await?;
 
         // Steps to insert a whole stats bundle
@@ -208,7 +260,7 @@ pub struct GetPlayerStats {
 }
 
 impl Message for GetPlayerStats {
-    type Result = Result<Option<PlayerStatsResponse>, StatisticsDatabaseError>;
+    type Result = StatisticsDatabaseResult<Option<PlayerStatsResponse>>;
 }
 
 #[async_trait]
@@ -221,13 +273,26 @@ impl Handler<GetPlayerStats> for StatisticDatabaseController {
 pub struct GetGameStats(pub Uuid);
 
 impl Message for GetGameStats {
-    type Result = Result<Option<HashMap<Uuid, PlayerStatsResponse>>, StatisticsDatabaseError>;
+    type Result = StatisticsDatabaseResult<Option<HashMap<Uuid, PlayerStatsResponse>>>;
 }
 
 #[async_trait]
 impl Handler<GetGameStats> for StatisticDatabaseController {
     async fn handle(&mut self, message: GetGameStats, _ctx: &mut Context<Self>) -> <GetGameStats as Message>::Result {
         self.get_game_stats(&message.0).await
+    }
+}
+
+pub struct GetRecentGames(pub u32);
+
+impl Message for GetRecentGames {
+    type Result = StatisticsDatabaseResult<Vec<RecentGame>>;
+}
+
+#[async_trait]
+impl Handler<GetRecentGames> for StatisticDatabaseController {
+    async fn handle(&mut self, message: GetRecentGames, _ctx: &mut Context<Self>) -> <GetRecentGames as Message>::Result {
+        self.get_recent_games(message.0).await
     }
 }
 
@@ -260,3 +325,5 @@ pub enum StatisticsDatabaseError {
     #[error("unknown error")]
     UnknownError,
 }
+
+pub type StatisticsDatabaseResult<T> = Result<T, StatisticsDatabaseError>;

--- a/src/statistics/model.rs
+++ b/src/statistics/model.rs
@@ -55,14 +55,6 @@ pub type PlayerStatsResponse = HashMap<String, HashMap<String, f64>>;
 pub type PlayerStatsBundle = HashMap<Uuid, HashMap<String, UploadStat>>;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct GameStatsResponse {
-    namespace: String,
-    player_count: i32,
-    server: String,
-    date_played: DateTime<Utc>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GameStatsBundle {
     pub namespace: String,
     pub stats: StatsBundle,
@@ -72,6 +64,15 @@ pub struct GameStatsBundle {
 pub struct StatsBundle {
     pub global: Option<HashMap<String, UploadStat>>,
     pub players: PlayerStatsBundle,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct RecentGame {
+    pub id: Uuid,
+    pub namespace: String,
+    pub players: Vec<Uuid>,
+    pub server: String,
+    pub date_played: DateTime<Utc>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
Adds a `/games/recent` endpoint for querying a list of information about recent games

Also adds a version of the docker-compose file for doing development, that just includes the two database servers

### TODO:
- [x] Add endpoint for querying a player's recent games
- [x] Update docs in [NucleoidMC/nucleoid-docs](https://github.com/NucleoidMC/nucleoid-docs)